### PR TITLE
Add raw mmtype function and mmver handling

### DIFF
--- a/include/hpgp.h
+++ b/include/hpgp.h
@@ -105,6 +105,7 @@ size_t hpgp_encode_response(struct hpgp_frame *hpgp, hpgp_mmtype_t type,
 hpgp_mmtype_t hpgp_mmtype(const struct hpgp_frame *hpgp);
 hpgp_variant_t hpgp_variant(const struct hpgp_frame *hpgp);
 hpgp_entity_t hpgp_entity(const struct hpgp_frame *hpgp);
+hpgp_mmtype_t hpgp_mmtype_raw(const struct hpgp_frame *hpgp);
 
 int hpgp_set_header(struct hpgp_frame *hpgp, hpgp_variant_t variant,
 		hpgp_entity_t entity, hpgp_mmtype_t type);


### PR DESCRIPTION
This pull request includes several changes to the `hpgp` module, focusing on enhancing the handling of `mmtype` and `mmver` values. The most important changes include adding a new function for raw `mmtype` retrieval, defining a default `mmver` value, and updating the header application function to use the new `mmver` value.

Enhancements to `mmtype` handling:

* [`include/hpgp.h`](diffhunk://#diff-178f310f8180caff44617cfa63a9baf0f99217a1e08f2885a7ea4af61a100e34R108): Added the declaration for the new function `hpgp_mmtype_raw` to retrieve the raw `mmtype` value.

Enhancements to `mmver` handling:

* [`src/hpgp.c`](diffhunk://#diff-a848d749f67ba6f6bb47c32d5f54509bbcd64f9177cffd755d6087e698a79cc8R12-R15): Defined a default `mmver` value using a preprocessor macro and included conditional compilation to set `HPGP_MMVER` if not already defined.
* [`src/hpgp.c`](diffhunk://#diff-a848d749f67ba6f6bb47c32d5f54509bbcd64f9177cffd755d6087e698a79cc8L45-R53): Modified the `apply_header` function to include an additional `mmv` parameter, allowing the `mmver` value to be set dynamically.
* [`src/hpgp.c`](diffhunk://#diff-a848d749f67ba6f6bb47c32d5f54509bbcd64f9177cffd755d6087e698a79cc8R71-R77): Updated the `set_header` function to determine the appropriate `mmver` value based on the `entity` parameter and pass it to the `apply_header` function.

Additional function implementation:

* [`src/hpgp.c`](diffhunk://#diff-a848d749f67ba6f6bb47c32d5f54509bbcd64f9177cffd755d6087e698a79cc8R238-R242): Implemented the `hpgp_mmtype_raw` function to return the raw `mmtype` value using the `get_mmtype` function.